### PR TITLE
Fix a very silly bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Alternatives
 * [Fedifeed](https://fedifeed.com): Like Mastofeed, but for other ActivityPub software too.
 * [untitled embed script from idotj](https://gitlab.com/idotj/mastodon-embed-feed-timeline): Also client-side. I wanted something with secure HTML embedding, automatic username lookup, and simpler URL-based configuration.
 
+Changelog
+---------
+
+* v1.0.1: Fix an incorrect URL when `data-toot-account-id` is not provided.
+* v1.0.0: Initial release.
+
 Author
 ------
 

--- a/emfed.ts
+++ b/emfed.ts
@@ -47,7 +47,7 @@ async function loadToots(element: Element) {
       // Look up user ID from username.
       const lookupURL = Object.assign(new URL(userURL), {
         pathname: "/api/v1/accounts/lookup",
-        lookupURL: `?acct=${username}`,
+        search: `?acct=${username}`,
       });
       return (await (await fetch(lookupURL)).json())["id"];
     })();


### PR DESCRIPTION
This would result in silent failures when `data-toot-account-id` was not provided (which, as it happens, is not something I was testing on my sites).