### PR TITLE
Add support for boosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Hacking
 An easy way to work with the code is with the [Packup][] bundler for [Deno][].
 Type `make dev` to serve an example page.
 
-Some missing features you might be interested in contributing include rendering media (ideally including their [BlurHash][] placeholder), filtering out replies, and displaying boosts appropriately.
+Some missing features you might be interested in contributing include rendering media (ideally including their [BlurHash][] placeholder) and filtering out replies.
 
 [BlurHash]: https://blurha.sh/
 [deno]: https://deno.land/
@@ -54,6 +54,7 @@ Alternatives
 Changelog
 ---------
 
+* v1.1.0: Display boosts (reblogs) correctly.
 * v1.0.1: Fix an incorrect URL when `data-toot-account-id` is not provided.
 * v1.0.0: Initial release.
 

--- a/toots.css
+++ b/toots.css
@@ -46,11 +46,11 @@
 .toot .boost {
   height: 23px;
   margin-bottom: 0.25rem;
+  column-gap: 0.25rem;
 }
 
-.toot .boost:after {
-  content: "boosted ♺";
-  color: #ccc;
+.toot .boost .display-name:after {
+  content: " ♺";
 }
 
 .toot .boost .display-name {

--- a/toots.css
+++ b/toots.css
@@ -10,12 +10,14 @@
   padding: 1rem;
 }
 
+/* Posting user. */
 .toot .user {
   display: flex;
   flex-flow: column wrap;
   justify-content: space-evenly;
   align-content: flex-start;
   height: 46px;  /* Avatar height. */
+  column-gap: 0.5rem;
 
   text-decoration: none;
   color: inherit;
@@ -23,7 +25,6 @@
 
 .toot .avatar {
   border-radius: 4px;
-  margin-right: 0.5rem;
 }
 
 .toot .display-name {
@@ -39,6 +40,25 @@
   display: block;
   margin-right: 1em;
   color: #999;
+}
+
+/* Boosting user is smaller and above the posting user. */
+.toot .boost {
+  height: 23px;
+  margin-bottom: 0.25rem;
+}
+
+.toot .boost:after {
+  content: "boosted ♺";
+  color: #ccc;
+}
+
+.toot .boost .display-name {
+  color: #ccc;
+}
+
+.toot .boost .username {
+  display: none;
 }
 
 .toot .permalink {

--- a/toots.css
+++ b/toots.css
@@ -49,12 +49,9 @@
   column-gap: 0.25rem;
 }
 
-.toot .boost .display-name:after {
-  content: " ♺";
-}
-
-.toot .boost .display-name {
-  color: #ccc;
+.toot .boost:before {
+  content: "♺";
+  font-size: 140%;
 }
 
 .toot .boost .username {


### PR DESCRIPTION
Previously, boosts didn't display at all—you just got the avatar. Now we show the original toot with a marker above it crediting the booster.

I am *really* not a designer and this is a surprisingly tricky thing to do in a small space, so I went with the easiest/dumbest possible way to display boosts—with the hope it can be improved in the future:

<img width="415" alt="Screenshot 2022-12-12 at 7 46 28 PM" src="https://user-images.githubusercontent.com/188033/207221612-3da79146-1529-4ab1-b4db-c3cea7693f8f.png">

That's [U+267A ♺ Recycling Symbol for Generic Materials](https://unicode-table.com/en/267A/) up in there.