### PR TITLE
Add support for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Hacking
 An easy way to work with the code is with the [Packup][] bundler for [Deno][].
 Type `make dev` to serve an example page.
 
-Some missing features you might be interested in contributing include rendering media (ideally including their [BlurHash][] placeholder) and filtering out replies.
+Some missing features you might be interested in contributing include rendering media beyond static images (GIFs, videos, and audio), using a [BlurHash][] placeholder before media has loaded, and optionally filtering out replies or boosts.
 
 [BlurHash]: https://blurha.sh/
 [deno]: https://deno.land/
@@ -54,6 +54,7 @@ Alternatives
 Changelog
 ---------
 
+* v1.2.0: Display image attachments.
 * v1.1.0: Display boosts (reblogs) correctly.
 * v1.0.1: Fix an incorrect URL when `data-toot-account-id` is not provided.
 * v1.0.0: Initial release.

--- a/emfed.ts
+++ b/emfed.ts
@@ -14,6 +14,13 @@ interface Toot {
     url: string;
   };
   reblog?: Toot;
+  media_attachments: {
+    type: "unknown" | "image" | "gifv" | "video" | "audio";
+    url: string;
+    preview_url: string;
+    description: string;
+    blurhash: string;
+  }[];
 }
 
 const TOOT_TMPL = `
@@ -34,6 +41,9 @@ const TOOT_TMPL = `
     <span class="username">@{{username}}</span>
   </a>
   <div class="body">{{{body}}}</div>
+  {{#images}}
+  <img class="attachment" src="{{preview_url}}" alt="{{description}}">
+  {{/images}}
 </li>
 `;
 
@@ -60,6 +70,7 @@ function renderToot(toot: Toot): string {
     user_url: toot.account.url,
     url: toot.url,
     boost,
+    images: toot.media_attachments,
   });
 }
 

--- a/emfed.ts
+++ b/emfed.ts
@@ -42,7 +42,10 @@ const TOOT_TMPL = `
   </a>
   <div class="body">{{{body}}}</div>
   {{#images}}
-  <img class="attachment" src="{{url}}" alt="{{alt}}">
+  <a class="attachment" href="{{orig_url}}"
+   target="_blank" rel="noopener noreferrer">
+    <img class="attachment" src="{{url}}" alt="{{alt}}">
+  </a>
   {{/images}}
 </li>
 `;
@@ -75,6 +78,7 @@ function renderToot(toot: Toot): string {
       .map(att => {
         return {
           url: att.preview_url,
+          orig_url: att.url,
           alt: att.description,
         };
     }),

--- a/emfed.ts
+++ b/emfed.ts
@@ -42,7 +42,7 @@ const TOOT_TMPL = `
   </a>
   <div class="body">{{{body}}}</div>
   {{#images}}
-  <img class="attachment" src="{{preview_url}}" alt="{{description}}">
+  <img class="attachment" src="{{url}}" alt="{{alt}}">
   {{/images}}
 </li>
 `;
@@ -70,7 +70,14 @@ function renderToot(toot: Toot): string {
     user_url: toot.account.url,
     url: toot.url,
     boost,
-    images: toot.media_attachments,
+    images: toot.media_attachments
+      .filter(att => att.type === "image")
+      .map(att => {
+        return {
+          url: att.preview_url,
+          alt: att.description,
+        };
+    }),
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emfed",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "embed a Mastodon feed in a webpage",
   "main": "dist/emfed.js",
   "type": "module",

--- a/toots.css
+++ b/toots.css
@@ -92,6 +92,15 @@
   content: "…";
 }
 
-.toot img.attachment {
+.toot .attachment {
+  display: block;
   width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 4px;
+}
+
+.toot .attachment img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }

--- a/toots.css
+++ b/toots.css
@@ -91,3 +91,7 @@
 .toot .body .ellipsis::after {
   content: "…";
 }
+
+.toot img.attachment {
+  width: 100%;
+}


### PR DESCRIPTION
Image attachments are now shown in a 16:9 preview, much like the Mastodon app. This does not include support for "gifv" GIFs, video, or audio. I also didn't include support for the "focus area" when cropping the preview (not exactly sure how to do that TBH). It would also be cool to add BlurHash previews before the media has loaded—someday.

Here's what it currently looks like:

<img width="477" alt="Screen Shot 2022-12-13 at 3 57 44 PM" src="https://user-images.githubusercontent.com/188033/207471058-2745785a-2744-48ec-b882-90b6c134453b.png">
