### PR TITLE
Improve our home-brew templating system

### DIFF
--- a/emfed.ts
+++ b/emfed.ts
@@ -39,6 +39,13 @@ function safe(s: string): SafeString {
   return Object.assign(new String(s), {__safe: null});
 }
 
+/**
+ * Values that can be used in our template system.
+ *
+ * Arrays are automatically joined. Null & undefined appear as empty strings,
+ * so you can do `value && str` to conditionally include `str` in a template
+ * (and otherwise include nothing).
+ */
 type TmpVal = string | SafeString | TmpVal[] | undefined | null;
 
 /**

--- a/emfed.ts
+++ b/emfed.ts
@@ -109,12 +109,12 @@ function renderToot(toot: Toot): string {
     <span class="username">@${toot.account.username}</span>
   </a>
   <div class="body">${safe(DOMPurify.sanitize(toot.content))}</div>
-  ${safe(images.map(att => html`
+  ${images.map(att => html`
   <a class="attachment" href="${att.url}"
    target="_blank" rel="noopener noreferrer">
     <img class="attachment" src="${att.preview_url}"
       alt="${att.description}">
-  </a>`).join(""))}
+  </a>`)}
 </li>`.toString();
 }
 

--- a/emfed.ts
+++ b/emfed.ts
@@ -39,13 +39,15 @@ function safe(s: string): SafeString {
   return Object.assign(new String(s), {__safe: null});
 }
 
-type TmpVal = string | SafeString | TmpVal[];
+type TmpVal = string | SafeString | TmpVal[] | undefined | null;
 
 /**
  * Format a value as a string for templating.
  */
 function flat(v: TmpVal): string | SafeString {
-  if (typeof(v) === "string" || v instanceof String) {
+  if (typeof(v) === "undefined" || v === null) {
+    return "";
+  } else if (typeof(v) === "string" || v instanceof String) {
     if (v.hasOwnProperty("__safe")) {
       return v;
     } else {
@@ -97,12 +99,12 @@ function renderToot(toot: Toot): string {
   <a class="permalink" href="${toot.url}">
     <time datetime="${toot.created_at}">${date}</time>
   </a>
-  ${boost ? html`
+  ${boost && html`
   <a class="user boost" href="${boost.user_url}">
     <img class="avatar" width="23" height="23" src="${boost.avatar}">
     <span class="display-name">${boost.display_name}</span>
     <span class="username">@${boost.username}</span>
-  </a>` : ""}
+  </a>`}
   <a class="user" href="${toot.account.url}">
     <img class="avatar" width="46" height="46" src="${toot.account.avatar}">
     <span class="display-name">${toot.account.display_name}</span>

--- a/emfed.ts
+++ b/emfed.ts
@@ -39,34 +39,23 @@ function esc(s: string): string {
  * A wrapped string that indicates that it's safe to include in HTML without
  * escaping.
  */
-class SafeString {
-  str: string;
-
-  constructor(s: string) {
-    this.str = s;
-  }
-
-  toString(): string {
-    return this.str;
-  }
-}
+type SafeString = string & {__safe: null};
 
 /**
  * Mark a string as safe for inclusion in HTML.
  */
 function safe(s: string): SafeString {
-  return new SafeString(s);
+  return Object.assign(s, {__safe: null});
 }
 
 /**
  * The world's dumbest templating system.
  */
-function html(strings: TemplateStringsArray,
-              ...subs: (string | SafeString)[]): SafeString {
+function html(strings: TemplateStringsArray, ...subs: string[]): SafeString {
   let out = strings[0];
   for (let i = 1; i < strings.length; ++i) {
     const sub = subs[i - 1];
-    out += (sub instanceof SafeString) ? sub.str : esc(sub);
+    out += sub.hasOwnProperty("__safe") ? sub : esc(sub);
     out += strings[i];
   }
   return safe(out);
@@ -114,7 +103,7 @@ function renderToot(toot: Toot): string {
     <img class="attachment" src="${att.preview_url}"
       alt="${att.description}">
   </a>`).join(""))}
-</li>`.toString();
+</li>`;
 }
 
 /**


### PR DESCRIPTION
It's not very fancy, but it does the job! Now the template itself can be a bit simpler, without the need for some `toString()` and `.join("")` and `?:` uses.