### PR TITLE
Fix uses of `element.dataset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Alternatives
 Changelog
 ---------
 
-* v1.3.0: Drop the dependency on [Mustache][].
+* v1.3.0: Drop the dependency on [Mustache][]. Fix a bug where, on some browsers, the `data-*` attributes would not work (so we'd always use the default configuration).
 * v1.2.0: Display image attachments.
 * v1.1.0: Display boosts (reblogs) correctly.
 * v1.0.1: Fix an incorrect URL when `data-toot-account-id` is not provided.

--- a/emfed.ts
+++ b/emfed.ts
@@ -137,7 +137,7 @@ async function loadToots(element: Element) {
 
   // Get the user ID, either from an explicit `data-toot-account-id` attribute
   // or by looking it up based on the username in the link.
-  const userId: string = el.dataset["toot-account-id"] ??
+  const userId: string = el.dataset.tootAccountId ??
     await (async () => {
       // Extract username from URL.
       const parts = /@(\w+)$/.exec(userURL.pathname);
@@ -155,7 +155,7 @@ async function loadToots(element: Element) {
     })();
 
   // Fetch toots. Count comes from `data-toot-limit` attribute.
-  const limit = el.dataset["toot-limit"] ?? "5";
+  const limit = el.dataset.tootLimit ?? "5";
   const tootURL = Object.assign(new URL(userURL), {
     pathname: `/api/v1/accounts/${userId}/statuses`,
     search: `?limit=${limit}`,


### PR DESCRIPTION
Looks like you have to use a weird camel-case conversion to access these values! Thanks for figuring this out, @acroyear.