### PR TITLE
Update package metadata so the npmjs.com page includes a GitHub link

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "emfed",
   "version": "1.3.0",
   "description": "embed a Mastodon feed in a webpage",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sampsyo/emfed.git"
+  },
   "main": "dist/emfed.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Coming from the NPM website, I had trouble finding the source code for this project:

<kbd>
<img src="https://github.com/sampsyo/emfed/assets/4673363/72067d72-cacb-4801-be55-84002a6e0822" width="600" />
</kbd>


&nbsp;

With this change, the NPM website will link to the GitHub project.