### PR TITLE
Minor build updates

### DIFF
--- a/emfed.ts
+++ b/emfed.ts
@@ -1,4 +1,4 @@
-import DOMPurify from "https://esm.sh/dompurify@2.4.1";
+import DOMPurify from "https://esm.sh/dompurify@3";
 
 /**
  * A Mastodon toot object, with just the fields of toots that we need.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "esbuild --outdir=dist emfed.ts",
     "prepack": "esbuild --outdir=dist emfed.ts"
   },
-  "dependencies": {
-    "esbuild": "^0.15.16"
+  "devDependencies": {
+    "esbuild": "^0.19.2"
   }
 }


### PR DESCRIPTION
A follow-on to #10. I originally wanted an `esbuild` setup that would automatically bundle our dependency on DOMPurify, but I haven't figured that out yet! I would love to either:

* find a plugin for esbuild (or even some other bundler) that will automatically download and include that dependency from esm.sh
* find a different plugin that supports [import maps](https://github.com/WICG/import-maps) to accomplish something similar but my remapping the URL import to a use of the dependency directly from npm

Maybe I'm misguided in trying to use a web-native style for this library and should just give up altogether…

Anyway, I also bumped the version of DOMPurify we're using, in preparation for someday remapping the simpler URL.