### PR TITLE
Make auto-replacement optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Emfed sanitizes the HTML contents of toots using [DOMPurify][] to avoid maliciou
 [eftm]: https://atp.fm/115
 [DOMPurify]: https://github.com/cure53/DOMPurify
 
+Using via the API
+-----------------
+
+By default, Emfed automatically transforms all the special Mastodon links it finds on the page.
+You can also instead invoke it programmatically, in which case you will want to instruct it not to automatically transform anything:
+
+    import { loadToots } from "emfed?auto=off";
+    document.querySelectorAll(".my-feed-class").forEach(loadToots);
+
+Use the `?auto=off` URL parameter to disable the automatic behavior.
+Then, call the `loadToots` function on any element to replace it with a Mastodon feed as described above.
+
 Hacking
 -------
 

--- a/emfed.ts
+++ b/emfed.ts
@@ -140,7 +140,7 @@ function renderToot(toot: Toot): string {
  * Get the toots for an HTML element and replace that element with the
  * rendered toot list.
  */
-async function loadToots(element: Element) {
+export async function loadToots(element: Element) {
   const el = element as HTMLAnchorElement;
   const userURL = new URL(el.href);
 

--- a/emfed.ts
+++ b/emfed.ts
@@ -184,5 +184,22 @@ async function loadToots(element: Element) {
   }
 }
 
-// Automatically transform links with a special class.
-document.querySelectorAll("a.mastodon-feed").forEach(loadToots);
+/**
+ * Automatically transform links with a special class.
+ */
+export function loadAll() {
+  document.querySelectorAll("a.mastodon-feed").forEach(loadToots);
+}
+
+// By default, we automatically transform all links. But users can disable
+// this by supplying ?auto=off and instead manually invoking the API to
+// transform specific elements.
+if (
+  !(
+    import.meta &&
+    import.meta.url &&
+    new URL(import.meta.url).searchParams.get("auto") === "off"
+  )
+) {
+  loadAll();
+}


### PR DESCRIPTION
This is an alternative to #10 that makes things a little simpler. Now, there is still only one module file, but you can supply `?auto=off` to disable the auto-replacement feature.

What do you think about this alternative, @octogonz? Would this work for your SPA use case?