### PR TITLE
Switch to a "normal" npm project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,27 @@
 SRC := src/emfed.ts src/client.ts src/core.ts
 
-.PHONY: all dev site check
+.PHONY: all dev site check clean
 
-all: dist/emfed.js
-
-dev:
-	packup index.html
+all:
+	esbuild --outdir=dist $(SRC)
 
 check:
-	deno check --config tsconfig.json src/emfed.ts
+	tsc --noEmit
 
 # A bundled & minified version, if you want that.
 dist/emfed.bundle.js: $(SRC)
 	esbuild --bundle --minify --outfile=dist/emfed.bundle.js src/emfed.ts
 
 # The public site, for publishing to GitHub Pages.
-site: index.html $(SRC) toots.css
+site: index.html toots.css $(SRC)
 	rm -rf $@
 	mkdir -p $@
-	packup build --dist-dir $@ $<
+	cp index.html toots.css $@
+	esbuild --outdir=site --bundle $(SRC)
+
+# Auto-rebuild and serve the site, for development.
+dev: site
+	esbuild --outdir=site --bundle $(SRC) --servedir=site
+
+clean:
+	rm -rf dist site

--- a/index.html
+++ b/index.html
@@ -77,6 +77,6 @@ h1 a:hover {
          data-toot-account-id="13179"
          >@Mastodon@mastodon.social</a>
     </aside>
-    <script type="module" src="src/emfed.ts"></script>
+    <script type="module" src="emfed.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "emfed",
+  "version": "1.4.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "emfed",
+      "version": "1.4.1",
+      "license": "Unlicense",
+      "dependencies": {
+        "dompurify": "^3.0.6"
+      },
+      "devDependencies": {
+        "@types/dompurify": "^3.0.3",
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.3.tgz",
+      "integrity": "sha512-odiGr/9/qMqjcBOe5UhcNLOFHSYmKFOyr+bJ/Xu3Qp4k1pNPAlNLUVNNLcLfjQI7+W7ObX58EdD3H+3p3voOvA==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
+      "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ==",
+      "dev": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "dist/emfed.js",
   "type": "module",
   "scripts": {
-    "prepack": "esbuild --outdir=dist src/*.ts"
+    "prepack": "tsc"
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "prepack": "esbuild --outdir=dist src/*.ts"
   },
   "devDependencies": {
-    "esbuild": "^0.19.2"
+    "@types/dompurify": "^3.0.3",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "dompurify": "^3.0.6"
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,5 @@
-import { Toot, getToots } from "./client.ts";
-import DOMPurify from "https://esm.sh/dompurify@3";
+import { Toot, getToots } from "./client.js";
+import DOMPurify from "dompurify";
 
 /**
  * A wrapped string that indicates that it's safe to include in HTML without

--- a/src/emfed.ts
+++ b/src/emfed.ts
@@ -1,2 +1,2 @@
-import { loadAll } from "./core.ts";
+import { loadAll } from "./core.js";
 loadAll();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],
     "target": "esnext",
-    "module": "esnext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "outDir": "dist"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["esnext", "dom", "dom.iterable"]
+    "strict": true,
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
As suggested in #10, this abandons my experiment with writing "browser-style" (Deno-like) TypeScript, with the idea of authoring code as close as possible to being runnable in-browser. This—and in particular the "HTTP imports" that Deno advocates for—turns out to be super hard to support in a reasonable way. (I wished for a simple bundler that would just follow these imports and pack them up the same way as a local `node_modules` dependency, but that doesn't seem to exist.)

The result is a more "normal" npm workflow, where we need a normal `npm install` to get our dependencies, followed by `tsc` to build the JavaScript products. Hopefully this just makes things more predictable overall.