### PR TITLE
Add ability to exclude reblogs/boosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You can customize the feed with `data-` attributes:
 * `data-toot-limit`: The maximum number of toots to display.
 * `data-toot-account-id`: Emfed needs to make an extra API request to translate your human-readable username (like `@Mastodon`) into an internal ID (like 13179) before it can look up your toots. If you have [empathy for the machine][eftm], you can make everything faster by specifying the ID directly here.
 * `data-exclude-replies`: "true" or "false" according to whether or not you'd like to exclude replies. The default behavior is that replies are included.
+* `data-exclude-reblogs`: "true" or "false" according to whether or not you'd like to exclude reblogs/boosts. The default behavior is that reblogs/boosts are included.
 
 Emfed sanitizes the HTML contents of toots using [DOMPurify][] to avoid malicious markup and XSS attacks.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -30,6 +30,7 @@ export async function getToots(
   accountId?: string,
   limit?: number,
   excludeReplies?: boolean,
+  excludeReblogs?: boolean
 ): Promise<Toot[]> {
   const url = new URL(userURL);
 
@@ -56,7 +57,7 @@ export async function getToots(
   // Fetch toots.
   const tootURL = Object.assign(new URL(url), {
     pathname: `/api/v1/accounts/${userId}/statuses`,
-    search: `?limit=${limit ?? 5}&exclude_replies=${!!excludeReplies}`,
+    search: `?limit=${limit ?? 5}&exclude_replies=${!!excludeReplies}&exclude_reblogs=${!!excludeReblogs}`,
   });
 
   return await (await fetch(tootURL)).json();

--- a/src/core.ts
+++ b/src/core.ts
@@ -125,6 +125,7 @@ export async function loadToots(element: Element) {
     el.dataset.tootAccountId,
     Number(el.dataset.tootLimit ?? 5),
     el.dataset.excludeReplies === "true",
+    el.dataset.excludeReblogs === "true",
   );
 
   // Construct the HTML content.
@@ -162,7 +163,6 @@ export async function loadTootPostAndReplies(element: Element) {
  */
 export function loadAll() {
   document.querySelectorAll("a.mastodon-feed").forEach(loadToots);
- /* inspired by https://carlschwan.eu/2020/12/29/adding-comments-to-your-static-blog-with-mastodon/ */  
- document.querySelectorAll("a.mastodon-thread").forEach(loadTootPostAndReplies)
-
+  /* inspired by https://carlschwan.eu/2020/12/29/adding-comments-to-your-static-blog-with-mastodon/ */  
+  document.querySelectorAll("a.mastodon-thread").forEach(loadTootPostAndReplies)
 }


### PR DESCRIPTION
Use 'data-exclude-reblogs' to filter out reblogs/boosts.