### PR TITLE
Fixes to responsive behaviour, adapted the look slightly closer to vanilla Mastodon, added ability to filter out 'self replies', added ability to format the date of each post.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ You can customize the feed with `data-` attributes:
 * `data-toot-limit`: The maximum number of toots to display.
 * `data-toot-account-id`: Emfed needs to make an extra API request to translate your human-readable username (like `@Mastodon`) into an internal ID (like 13179) before it can look up your toots. If you have [empathy for the machine][eftm], you can make everything faster by specifying the ID directly here.
 * `data-exclude-replies`: "true" or "false" according to whether or not you'd like to exclude replies. The default behavior is that replies are included.
+* `data-exclude-self-replies`: "true" or "false" according to whether or not you'd like to exclude replies to its own account. The default behavior is that replies are included. This is a workaround for https://github.com/mastodon/mastodon/pull/23257 as that won't be fixed. If self-replies get filtered out, the amount of displayed toots is reduced.
 * `data-exclude-reblogs`: "true" or "false" according to whether or not you'd like to exclude reblogs/boosts. The default behavior is that reblogs/boosts are included.
+
+You can customize how the feed is rendered with further `data-` attributes:
+
+* `data-locale`: Locale to render the date of each toot. The default behavior is that the webbrowsers locale will be taken. Should that not be available, `en-US` will be used as a fallback.
+* `data-ts_format`: JSON object to define how to render the date. The default object is `'{"month": "long", "day": "numeric"}'`. Please be sure to use double quotes within the JSON string.
 
 Emfed sanitizes the HTML contents of toots using [DOMPurify][] to avoid malicious markup and XSS attacks.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@
 export interface Toot {
   created_at: string;
   in_reply_to_id: string | null;
+  in_reply_to_account_id: string | null;
   content: string;
   url: string;
   account: {

--- a/toots.css
+++ b/toots.css
@@ -10,29 +10,78 @@
   padding: 1rem;
 }
 
-/* Posting user. */
-.toot .user {
+/* Boosting user is smaller and above the posting user/header. */
+.toot .boost {
+  height: 23px;
+  margin-bottom: 0.25rem;
+  column-gap: 0.25rem;
+  font-size: 0.8em;
+  color: #999;
+}
+
+.toot .boost:before {
+  content: "🔁"; /* changed from "♺" */
+}
+
+.toot .boost::after {
+  content: "boosted"; /* More inline with how mainstream Mastodon instances look */
+}
+
+.toot .boost .username {
+  display: none;
+}
+
+.toot .toot-header {
   display: flex;
-  flex-flow: column wrap;
-  justify-content: space-evenly;
+  flex-flow: row-reverse wrap;
+  gap: 10px;
+  justify-content: space-between;
+  padding-bottom: 10px;
+}
+
+.toot .toot-header .permalink {
+  display: block;
+  float: unset;
+  text-align: right;
+  text-decoration: none;
+  color: #999;
+}
+
+.toot .toot-header .permalink:hover {
+  text-decoration: underline;
+}
+
+/* Posting user. */
+.toot .toot-header .user {
+  flex: 1;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
   align-content: flex-start;
   height: 46px;  /* Avatar height. */
   column-gap: 0.5rem;
 
+  text-align: left;
   text-decoration: none;
   color: inherit;
 }
 
-.toot .avatar {
+.toot .toot-header .user .user-display {
+  display: flex;
+  flex-flow: column nowrap;
+  text-wrap: nowrap;
+}
+
+.toot .toot-header .user .avatar {
   border-radius: 4px;
 }
 
-.toot .display-name {
+.toot .toot-header .user .user-display .display-name {
   font-weight: bold;
   display: block;
 }
 
-.toot .user:hover .display-name {
+.toot .toot-header .user:hover .display-name {
   text-decoration: underline;
 }
 
@@ -40,33 +89,6 @@
   display: block;
   margin-right: 1em;
   color: #999;
-}
-
-/* Boosting user is smaller and above the posting user. */
-.toot .boost {
-  height: 23px;
-  margin-bottom: 0.25rem;
-  column-gap: 0.25rem;
-}
-
-.toot .boost:before {
-  content: "♺";
-  font-size: 140%;
-}
-
-.toot .boost .username {
-  display: none;
-}
-
-.toot .permalink {
-  text-decoration: none;
-  display: block;
-  color: #999;
-  float: right;
-}
-
-.toot .permalink:hover {
-  text-decoration: underline;
 }
 
 .toot .body {


### PR DESCRIPTION
# Changelog
* Adapted the toot headers responsive behavior. It should no longer overlay the user and date over each other. This is done with a flex layout, just like in vanilla Mastodon.
* Adapted the boosting user to look a little closer to vanilla Mastodon. The color is darker and the boost-icon was changed from '♺' to '🔁'.
* Added the option to exclude self-replies. The Mastodon API will return replies on the same user despite the exclude_replies argument being set to true. This will not be changed on Mastodon's side.
* Changed how the date is formatted. The users' locale is used by default, and the date is formatted like in vanilla Mastodon. The full date is present in the title attribute.
* Added the options to override the default locale with the `data-locale` attribute and the date format options with the `data-ts_format` attribute.

I understand some of these changes are only stylistic and subject to personal taste, feel free to revert them as you wish. I generally tried to get this to look closer to vanilla Mastodon.