### PR TITLE
Support for custom emoji

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -90,3 +90,14 @@ export async function getPostAndReplyToots(
   }
   return toots;
 }
+
+export async function getEmojiMap(
+  instanceURL: string
+): Promise<Record<string, string>> {
+  const url = new URL(instanceURL);
+  url.pathname = "/api/v1/custom_emojis"; // https://docs.joinmastodon.org/methods/custom_emojis/#get
+  const emojiList: { shortcode: string; url: string }[] = 
+    await (await fetch(url)).json();
+  
+  return Object.fromEntries(emojiList.map(({ shortcode, url }) => [shortcode, url]));
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -96,8 +96,20 @@ export async function getEmojiMap(
 ): Promise<Record<string, string>> {
   const url = new URL(instanceURL);
   url.pathname = "/api/v1/custom_emojis"; // https://docs.joinmastodon.org/methods/custom_emojis/#get
-  const emojiList: { shortcode: string; url: string }[] = 
-    await (await fetch(url)).json();
-  
+  const emojiList: { shortcode: string; url: string }[] =
+    await (await fetchWithTimeout(url)).json();
+
   return Object.fromEntries(emojiList.map(({ shortcode, url }) => [shortcode, url]));
+}
+
+// Waits 2 seconds for an API response
+async function fetchWithTimeout(url: URL, ms = 2000): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  }
+  finally {
+    clearTimeout(timer);
+  }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -142,7 +142,7 @@ export async function loadToots(element: Element) {
   const emojiMaps: Record<string, Record<string, string>> = {};
   await Promise.all(
     [...servers].map(async (server) => {
-      emojiMaps[server] = await getEmojiMap(server);
+      emojiMaps[server] = await getEmojiMap(server).catch(() => ({}));
     })
   );
 
@@ -181,7 +181,7 @@ export async function loadTootPostAndReplies(element: Element) {
   const emojiMaps: Record<string, Record<string, string>> = {};
   await Promise.all(
     [...servers].map(async (server) => {
-      emojiMaps[server] = await getEmojiMap(server);
+      emojiMaps[server] = await getEmojiMap(server).catch(() => ({}));
     })
   );
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -63,7 +63,7 @@ function html(strings: TemplateStringsArray, ...subs: TmpVal[]): SafeString {
 /**
  * Render a single toot object as an HTML string.
  */
-function renderToot(toot: Toot, emojiMap: Record<string, string> = {}): string {
+function renderToot(toot: Toot, emojiMap: Record<string, string> = {}, boostEmojiMap: Record<string, string> = {}): string {
   // Is this a boost (reblog)?
   let boost = null;
   if (toot.reblog) {
@@ -78,7 +78,7 @@ function renderToot(toot: Toot, emojiMap: Record<string, string> = {}): string {
 
   const date = new Date(toot.created_at).toLocaleString();
   const images = toot.media_attachments.filter((att) => att.type === "image");
-  const contentWithEmojis = insertEmojis(toot.content, emojiMap);
+  const contentWithEmojis = insertEmojis(toot.content, boost ? boostEmojiMap : emojiMap);
 
   return html`<li class="toot">
     <a class="permalink" href="${toot.url}">
@@ -87,12 +87,12 @@ function renderToot(toot: Toot, emojiMap: Record<string, string> = {}): string {
     ${boost &&
     html` <a class="user boost" href="${boost.user_url}">
       <img class="avatar" width="23" height="23" src="${boost.avatar}" />
-      <span class="display-name">${safe(DOMPurify.sanitize(insertEmojis(toot.account.display_name, emojiMap)))}</span>
+      <span class="display-name">${safe(DOMPurify.sanitize(insertEmojis(boost.display_name, emojiMap)))}</span>
       <span class="username">@${boost.username}</span>
     </a>`}
     <a class="user" href="${toot.account.url}">
       <img class="avatar" width="46" height="46" src="${toot.account.avatar}" />
-      <span class="display-name">${safe(DOMPurify.sanitize(insertEmojis(toot.account.display_name, emojiMap)))}</span>
+      <span class="display-name">${safe(DOMPurify.sanitize(insertEmojis(toot.account.display_name, boost ? boostEmojiMap : emojiMap)))}</span>
       <span class="username">@${toot.account.username}</span>
     </a>
     <div class="body">${safe(DOMPurify.sanitize(contentWithEmojis))}</div>
@@ -121,25 +121,43 @@ function renderToot(toot: Toot, emojiMap: Record<string, string> = {}): string {
 export async function loadToots(element: Element) {
   // Fetch toots based on the element's `data-toot-*` attributes.
   const el = element as HTMLAnchorElement;
-  
-  // Fetch toots and emojis concurrently
-  const [toots, emojiMap] = await Promise.all([
-    getToots(
-      el.href,
-      el.dataset.tootAccountId,
-      Number(el.dataset.tootLimit ?? 5),
-      el.dataset.excludeReplies === "true",
-      el.dataset.excludeReblogs === "true",
-    ),
-    getEmojiMap(el.href)
-  ]);
+  const toots = await getToots(
+    el.href,
+    el.dataset.tootAccountId,
+    Number(el.dataset.tootLimit ?? 5),
+    el.dataset.excludeReplies === "true",
+    el.dataset.excludeReblogs === "true",
+  );
+
+  // Collect unique servers from toots/boosts
+  const servers = new Set<string>();
+  for (const toot of toots) {
+    servers.add(new URL(toot.account.url).origin);
+    if (toot.reblog) {
+      servers.add(new URL(toot.reblog.account.url).origin);
+    }
+  }
+
+  // Grab emoji mappings from servers listed in aforementioned toots/boosts
+  const emojiMaps: Record<string, Record<string, string>> = {};
+  await Promise.all(
+    [...servers].map(async (server) => {
+      emojiMaps[server] = await getEmojiMap(server);
+    })
+  );
 
   // Construct the HTML content.
   const list = document.createElement("ol");
   list.classList.add("toots");
   el.replaceWith(list);
+
+  // Get the relevant emojis needed to render the post
   for (const toot of toots) {
-    const html = renderToot(toot, emojiMap);
+    const emojiMap = emojiMaps[new URL(toot.account.url).origin] ?? {};
+    const boostEmojiMap = toot.reblog
+      ? emojiMaps[new URL(toot.reblog.account.url).origin] ?? {}
+      : {};
+    const html = renderToot(toot, emojiMap, boostEmojiMap);
     list.insertAdjacentHTML("beforeend", html);
   }
 }
@@ -153,20 +171,36 @@ export async function loadTootPostAndReplies(element: Element) {
     el.dataset.excludePost === "true",
   );
 
+  // Collect unique servers from toots/replies
+  const servers = new Set<string>();
+  for (const toot of toots) {
+    servers.add(new URL(toot.account.url).origin);
+  }
+
+  // Grab emoji mappings from servers listed in aforementioned toots/replies
+  const emojiMaps: Record<string, Record<string, string>> = {};
+  await Promise.all(
+    [...servers].map(async (server) => {
+      emojiMaps[server] = await getEmojiMap(server);
+    })
+  );
+
   // Construct the HTML content.
   const replies = document.createElement("ol");
   replies.classList.add("toots");
   el.replaceWith(replies);
   for (const toot of toots) {
-    const html = renderToot(toot);
+    const emojiMap = emojiMaps[new URL(toot.account.url).origin] ?? {};
+    const html = renderToot(toot, emojiMap);
     replies.insertAdjacentHTML("beforeend", html);
-  }  
+  }
 }
 
+// Replaces shortcodes with custom emoji images
 function insertEmojis(content: string, emojiMap: Record<string, string>): string {
   return content.replace(/:([a-zA-Z0-9_]+):/g, (match, shortcode) => {
     const url = emojiMap[shortcode];
-    if (!url) return match; // not a custom emoji
+    if (!url) return match; // If shortcode isn't in emojiMap, displays shortcode as fallback
     return `<img class="custom-emoji" src="${url}" alt=":${shortcode}:" title=":${shortcode}:"/>`;
   });
 }
@@ -176,6 +210,6 @@ function insertEmojis(content: string, emojiMap: Record<string, string>): string
  */
 export function loadAll() {
   document.querySelectorAll("a.mastodon-feed").forEach(loadToots);
-  /* inspired by https://carlschwan.eu/2020/12/29/adding-comments-to-your-static-blog-with-mastodon/ */  
+  /* inspired by https://carlschwan.eu/2020/12/29/adding-comments-to-your-static-blog-with-mastodon/ */
   document.querySelectorAll("a.mastodon-thread").forEach(loadTootPostAndReplies)
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -201,7 +201,7 @@ function insertEmojis(content: string, emojiMap: Record<string, string>): string
   return content.replace(/:([a-zA-Z0-9_]+):/g, (match, shortcode) => {
     const url = emojiMap[shortcode];
     if (!url) return match; // If shortcode isn't in emojiMap, displays shortcode as fallback
-    return `<img class="custom-emoji" src="${url}" alt=":${shortcode}:" title=":${shortcode}:"/>`;
+    return `<img class="custom-emoji" loading="lazy" src="${url}" alt=":${shortcode}:" title=":${shortcode}:"/>`;
   });
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import { Toot, getToots, getPostAndReplyToots } from "./client.js";
+import { Toot, getToots, getPostAndReplyToots, getEmojiMap } from "./client.js";
 import DOMPurify from "dompurify";
 
 /**
@@ -63,7 +63,7 @@ function html(strings: TemplateStringsArray, ...subs: TmpVal[]): SafeString {
 /**
  * Render a single toot object as an HTML string.
  */
-function renderToot(toot: Toot): string {
+function renderToot(toot: Toot, emojiMap: Record<string, string> = {}): string {
   // Is this a boost (reblog)?
   let boost = null;
   if (toot.reblog) {
@@ -78,6 +78,7 @@ function renderToot(toot: Toot): string {
 
   const date = new Date(toot.created_at).toLocaleString();
   const images = toot.media_attachments.filter((att) => att.type === "image");
+  const contentWithEmojis = insertEmojis(toot.content, emojiMap);
 
   return html`<li class="toot">
     <a class="permalink" href="${toot.url}">
@@ -86,15 +87,15 @@ function renderToot(toot: Toot): string {
     ${boost &&
     html` <a class="user boost" href="${boost.user_url}">
       <img class="avatar" width="23" height="23" src="${boost.avatar}" />
-      <span class="display-name">${boost.display_name}</span>
+      <span class="display-name">${safe(DOMPurify.sanitize(insertEmojis(toot.account.display_name, emojiMap)))}</span>
       <span class="username">@${boost.username}</span>
     </a>`}
     <a class="user" href="${toot.account.url}">
       <img class="avatar" width="46" height="46" src="${toot.account.avatar}" />
-      <span class="display-name">${toot.account.display_name}</span>
+      <span class="display-name">${safe(DOMPurify.sanitize(insertEmojis(toot.account.display_name, emojiMap)))}</span>
       <span class="username">@${toot.account.username}</span>
     </a>
-    <div class="body">${safe(DOMPurify.sanitize(toot.content))}</div>
+    <div class="body">${safe(DOMPurify.sanitize(contentWithEmojis))}</div>
     ${images.map(
       (att) =>
         html` <a
@@ -120,20 +121,25 @@ function renderToot(toot: Toot): string {
 export async function loadToots(element: Element) {
   // Fetch toots based on the element's `data-toot-*` attributes.
   const el = element as HTMLAnchorElement;
-  const toots = await getToots(
-    el.href,
-    el.dataset.tootAccountId,
-    Number(el.dataset.tootLimit ?? 5),
-    el.dataset.excludeReplies === "true",
-    el.dataset.excludeReblogs === "true",
-  );
+  
+  // Fetch toots and emojis concurrently
+  const [toots, emojiMap] = await Promise.all([
+    getToots(
+      el.href,
+      el.dataset.tootAccountId,
+      Number(el.dataset.tootLimit ?? 5),
+      el.dataset.excludeReplies === "true",
+      el.dataset.excludeReblogs === "true",
+    ),
+    getEmojiMap(el.href)
+  ]);
 
   // Construct the HTML content.
   const list = document.createElement("ol");
   list.classList.add("toots");
   el.replaceWith(list);
   for (const toot of toots) {
-    const html = renderToot(toot);
+    const html = renderToot(toot, emojiMap);
     list.insertAdjacentHTML("beforeend", html);
   }
 }
@@ -157,6 +163,13 @@ export async function loadTootPostAndReplies(element: Element) {
   }  
 }
 
+function insertEmojis(content: string, emojiMap: Record<string, string>): string {
+  return content.replace(/:([a-zA-Z0-9_]+):/g, (match, shortcode) => {
+    const url = emojiMap[shortcode];
+    if (!url) return match; // not a custom emoji
+    return `<img class="custom-emoji" src="${url}" alt=":${shortcode}:" title=":${shortcode}:"/>`;
+  });
+}
 
 /**
  * Transform all links on the page marked with the `mastodon-feed` class.

--- a/toots.css
+++ b/toots.css
@@ -104,3 +104,8 @@
   height: 100%;
   object-fit: cover;
 }
+
+.custom-emoji {
+  width: 1.25rem;
+  height: 1.25rem;
+}


### PR DESCRIPTION
Hi! I took a shot at adding emoji support by parsing the shortcodes within post/username text and replacing them with the corresponding images:

<img width="640" height="281" alt="image" src="https://github.com/user-attachments/assets/29c59865-e059-4f4d-a89e-7fe771e0b795" />

This PR handles fetching/displaying emojis from the user's posts, as well as emoji within boosts. There's also protection to ensure that the posts will still display if emoji fetching fails.

I deployed the changes [onto my neocities site](https://fieldswork.neocities.org/) if you want to take a look. I'm super open to discuss any revisions - thank you for your time!